### PR TITLE
Handle invalid date format in war tab

### DIFF
--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -300,16 +300,37 @@ class PlayerController extends Controller
             'endTime' => null
         ], $war);
 
-        // Parse timestamps
-        $war['prepStart'] = isset($war['preparationStartTime'])
-            ? \Carbon\Carbon::createFromFormat('Ymd\THis.v\Z', $war['preparationStartTime'])
-            : null;
-        $war['startTime'] = isset($war['startTime'])
-            ? \Carbon\Carbon::createFromFormat('Ymd\THis.v\Z', $war['startTime'])
-            : null;
-        $war['endTime'] = isset($war['endTime'])
-            ? \Carbon\Carbon::createFromFormat('Ymd\THis.v\Z', $war['endTime'])
-            : null;
+        // Parse timestamps safely
+        function safeParseDate($dateString) {
+            if (empty($dateString)) return null;
+            
+            $formats = [
+                'Ymd\THis.v\Z',  // 20231201T120000.000Z
+                'Y-m-d\TH:i:s.v\Z', // 2023-12-01T12:00:00.000Z
+                'Y-m-d\TH:i:s\Z',   // 2023-12-01T12:00:00Z
+                'Y-m-d\TH:i:s',     // 2023-12-01T12:00:00
+                'Y-m-d H:i:s',      // 2023-12-01 12:00:00
+            ];
+            
+            foreach ($formats as $format) {
+                try {
+                    return \Carbon\Carbon::createFromFormat($format, $dateString);
+                } catch (\Exception $e) {
+                    continue;
+                }
+            }
+            
+            // If all formats fail, try parsing as ISO string
+            try {
+                return \Carbon\Carbon::parse($dateString);
+            } catch (\Exception $e) {
+                return null;
+            }
+        }
+        
+        $war['prepStart'] = safeParseDate($war['preparationStartTime'] ?? null);
+        $war['startTime'] = safeParseDate($war['startTime'] ?? null);
+        $war['endTime'] = safeParseDate($war['endTime'] ?? null);
 
         // Sort clan members by map position
         if (isset($war['clan']['members']) && is_array($war['clan']['members']) && !empty($war['clan']['members'])) {

--- a/resources/views/clan/partials/cwl-war.blade.php
+++ b/resources/views/clan/partials/cwl-war.blade.php
@@ -25,11 +25,35 @@
             @php
                 use Carbon\Carbon;
 
-                try {
-                    $start = Carbon::createFromFormat('Ymd\THis.v\Z', $war['startTime'] ?? '');
-                } catch (\Exception $e) {
-                    $start = null;
+                // Safe date parsing
+                function safeParseDate($dateString) {
+                    if (empty($dateString)) return null;
+                    
+                    $formats = [
+                        'Ymd\THis.v\Z',  // 20231201T120000.000Z
+                        'Y-m-d\TH:i:s.v\Z', // 2023-12-01T12:00:00.000Z
+                        'Y-m-d\TH:i:s\Z',   // 2023-12-01T12:00:00Z
+                        'Y-m-d\TH:i:s',     // 2023-12-01T12:00:00
+                        'Y-m-d H:i:s',      // 2023-12-01 12:00:00
+                    ];
+                    
+                    foreach ($formats as $format) {
+                        try {
+                            return Carbon::createFromFormat($format, $dateString);
+                        } catch (\Exception $e) {
+                            continue;
+                        }
+                    }
+                    
+                    // If all formats fail, try parsing as ISO string
+                    try {
+                        return Carbon::parse($dateString);
+                    } catch (\Exception $e) {
+                        return null;
+                    }
                 }
+
+                $start = safeParseDate($war['startTime'] ?? null);
             @endphp
 
             <div class="italic text-xs text-gray-400">

--- a/resources/views/clan/partials/war-entry.blade.php
+++ b/resources/views/clan/partials/war-entry.blade.php
@@ -1,6 +1,34 @@
 
 @php
-    $endTime = isset($log['endTime']) ? \Carbon\Carbon::createFromFormat('Ymd\THis.v\Z', $log['endTime']) : null;
+    // Safe date parsing
+    function safeParseDate($dateString) {
+        if (empty($dateString)) return null;
+        
+        $formats = [
+            'Ymd\THis.v\Z',  // 20231201T120000.000Z
+            'Y-m-d\TH:i:s.v\Z', // 2023-12-01T12:00:00.000Z
+            'Y-m-d\TH:i:s\Z',   // 2023-12-01T12:00:00Z
+            'Y-m-d\TH:i:s',     // 2023-12-01T12:00:00
+            'Y-m-d H:i:s',      // 2023-12-01 12:00:00
+        ];
+        
+        foreach ($formats as $format) {
+            try {
+                return \Carbon\Carbon::createFromFormat($format, $dateString);
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+        
+        // If all formats fail, try parsing as ISO string
+        try {
+            return \Carbon\Carbon::parse($dateString);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+    
+    $endTime = safeParseDate($log['endTime'] ?? null);
     $result = isset($log['result']) ? $log['result'] : (
         isset($log['state']) && $log['state'] === 'warEnded' ? (
             ($log['clan']['stars'] > $log['opponent']['stars'] || 

--- a/resources/views/clan/partials/war.blade.php
+++ b/resources/views/clan/partials/war.blade.php
@@ -10,9 +10,38 @@
     $defenderNames = $clan['defenderNames'] ?? [];
     $isPreparation = $war['state'] === 'preparation';
     $isInWar = $war['state'] === 'inWar';
-    $prepStart = isset($war['preparationStartTime']) ? \Carbon\Carbon::createFromFormat('Ymd\THis.v\Z', $war['preparationStartTime']) : null;
-    $startTime = isset($war['startTime']) ? \Carbon\Carbon::createFromFormat('Ymd\THis.v\Z', $war['startTime']) : null;
-    $endTime = isset($war['endTime']) ? \Carbon\Carbon::createFromFormat('Ymd\THis.v\Z', $war['endTime']) : null;
+    
+    // Safe date parsing with multiple format attempts
+    function safeParseDate($dateString) {
+        if (empty($dateString)) return null;
+        
+        $formats = [
+            'Ymd\THis.v\Z',  // 20231201T120000.000Z
+            'Y-m-d\TH:i:s.v\Z', // 2023-12-01T12:00:00.000Z
+            'Y-m-d\TH:i:s\Z',   // 2023-12-01T12:00:00Z
+            'Y-m-d\TH:i:s',     // 2023-12-01T12:00:00
+            'Y-m-d H:i:s',      // 2023-12-01 12:00:00
+        ];
+        
+        foreach ($formats as $format) {
+            try {
+                return \Carbon\Carbon::createFromFormat($format, $dateString);
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+        
+        // If all formats fail, try parsing as ISO string
+        try {
+            return \Carbon\Carbon::parse($dateString);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+    
+    $prepStart = safeParseDate($war['preparationStartTime'] ?? null);
+    $startTime = safeParseDate($war['startTime'] ?? null);
+    $endTime = safeParseDate($war['endTime'] ?? null);
 @endphp
 
 <div id="webcrumbs">


### PR DESCRIPTION
Implement robust date parsing to prevent `Carbon\Exceptions\InvalidFormatException` from inconsistent API date formats.

The previous date parsing relied on a single strict format (`Ymd\THis.v\Z`), which caused crashes when the Clash of Clans API returned dates in slightly different but valid ISO formats. The new `safeParseDate` function attempts several common ISO formats and then falls back to `Carbon::parse()` for broader compatibility, ensuring the application handles various date string inputs gracefully.

---
<a href="https://cursor.com/background-agent?bcId=bc-eca721a2-6887-4c1c-824d-bd51aa209c0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eca721a2-6887-4c1c-824d-bd51aa209c0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

